### PR TITLE
wth - Documentation Update

### DIFF
--- a/app/views/examples/texts/interaction/actions/actions.md
+++ b/app/views/examples/texts/interaction/actions/actions.md
@@ -4,7 +4,7 @@ By default, ReportsKit shows two action buttons for each report: `Download CSV` 
 = render_report 'my_report', actions: []
 ```
 
-To only show one of the two, pass either `'export_csv'` or `'export_excel'` as the only array element:
+To only show one of the two, pass either `'export_csv'` or `'export_xls'` as the only array element:
 
 ```haml
 = render_report 'my_report', actions: ['export_csv']


### PR DESCRIPTION
Updated actions documentation
(https://www.reportskit.co/subcategories/actions)

Changed text to be:

To only show one of the two, pass either 'export_csv' or 'export_xls' as the only array element: